### PR TITLE
Add Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+dist: xenial
+services:
+    - docker
+language: go
+addons:
+    apt:
+        config:
+            retries: true
+        update: true
+        sources:
+            - sourceline: 'deb http://archive.ubuntu.com/ubuntu bionic main universe'
+        packages:
+            # To use upx command.
+            # upx 3.94 on bionic works.
+            # upx 3.91 on xenial does not work for amd64 case.
+            - upx-ucl
+install:
+    - make clean dist
+    - docker images
+script:
+    - docker run --rm multiarch/true:linux_amd64
+    - docker run --rm multiarch/true:linux_386
+    - |
+      if docker run --rm multiarch/true:linux_arm; then
+          false
+      else
+          true
+      fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# true
+# :earth_africa: true [![Build Status](https://travis-ci.org/multiarch/true.svg?branch=master)](https://travis-ci.org/multiarch/true)
 
 ![](https://raw.githubusercontent.com/multiarch/dockerfile/master/logo.jpg)
 


### PR DESCRIPTION
Right now this repository's Travis CI is failed.
https://travis-ci.org/multiarch/true/builds/120568786

This PR is to pass the CI, and to show people reproducing scripts in the repository.

Here is the succeeded result on my repository's CI.
https://travis-ci.org/junaruga/true/builds/540240562

Modified README is here.
https://github.com/junaruga/true/blob/feature/ci/README.md

Notes:

* On Travis CI' `go` lang mode, `GOPATH` and `PATH` are automatically set.
  To run `Makefile` on local, you need to set below kind of environment variables manually.

  ```
  export GOPATH=$(pwd)/gopath
  export PATH="${GOPATH}/bin:${PATH}"
  ```

* In the `Makefile` below applications are used. But both are implemented on newer version go according to the comments. On Travis default golang version is 1.11. On the version, maybe we can achieve what we want without the applications.

  https://github.com/laher/goxc
  > NOTE: goxc has long been in maintenance mode. Ever since Go1.5 supported simple cross-compilation, this tool lost much of its value. 

  https://github.com/pwaller/goupx
  > As far as I (pwaller) know, goupx is no longer necessary for Linux binaries since it was fixed in go1.6.

* By the `Makefile`, below container images are created.

  ```
  $ docker images
  REPOSITORY          TAG                 IMAGE ID            CREATED                  SIZE
  multiarch/true      linux_amd64         2bde08852cf9        Less than a second ago   584kB
  multiarch/true      linux_arm           9ff9e587cede        Less than a second ago   550kB
  multiarch/true      linux_386           2631747b657e        1 second ago             559kB
  ```

  However we can see additional images on https://hub.docker.com/r/multiarch/true/tags .
  Maybe additional tags are added by `docker tag` for convenience.


